### PR TITLE
Test script scaffold target should be the host

### DIFF
--- a/internal/artillery/script.go
+++ b/internal/artillery/script.go
@@ -93,9 +93,10 @@ func NewTestScript(probes kube.ServiceProbes) *TestScript {
 		}
 	}
 
+	testScriptTarget := fmt.Sprintf("%s://%s/", probes[0].Url.Scheme, probes[0].Url.Host)
 	return &TestScript{
 		Config: Config{
-			Target: probes[0].Url.String(),
+			Target: testScriptTarget,
 
 			Environments: map[string]Environment{
 				"functional": {


### PR DESCRIPTION
Resolves https://linear.app/artillery/issue/ART-459

## Updates

- Fixes the test script target to point to the domain host, while flow urls point to the actual probes.