### PR TITLE
Fix up telemetry settings in generated Jobs.

### DIFF
--- a/cmd/kubectl-artillery/main.go
+++ b/cmd/kubectl-artillery/main.go
@@ -31,12 +31,6 @@ const (
 
 	// WorkerImage the Artillery image used by workers to run load tests.
 	WorkerImage = "artilleryio/artillery:latest"
-
-	// TestScriptVol the volume used by created LoadTest Pods to load the test script ConfigMap.
-	TestScriptVol = "test-script"
-
-	// TestScriptFilename expected filename used by the test script ConfigMap.
-	TestScriptFilename = "test-script.yaml"
 )
 
 // kubectl-artillery CLI entrypoint

--- a/commands/generate.go
+++ b/commands/generate.go
@@ -43,7 +43,7 @@ func newCmdGenerate(
 		Aliases: []string{"gen"},
 		Short:   "Generates a k8s Job packaged with Kustomize to execute a test",
 		Example: fmt.Sprintf(generatetestExample, cliName),
-		RunE:    makeRunGenTest(workingDir, io),
+		RunE:    makeRunGenTest(workingDir, io, tCfg),
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			testScriptPath, _ := cmd.Flags().GetString("script")
 			ns, _ := cmd.Flags().GetString("namespace")
@@ -95,7 +95,7 @@ func newCmdGenerate(
 }
 
 // makeRunGenTest creates the RunE function used to generate a test
-func makeRunGenTest(workingDir string, io genericclioptions.IOStreams) func(cmd *cobra.Command, args []string) error {
+func makeRunGenTest(workingDir string, io genericclioptions.IOStreams, cfg telemetry.Config) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if err := validateTest(args); err != nil {
 			return err
@@ -137,7 +137,7 @@ func makeRunGenTest(workingDir string, io genericclioptions.IOStreams) func(cmd 
 			return err
 		}
 
-		job := artillery.NewTestJob(testName, ns, configMapName, filepath.Base(testScriptPath), count)
+		job := artillery.NewTestJob(testName, ns, configMapName, filepath.Base(testScriptPath), count, cfg)
 		kustomization := artillery.NewKustomization(artillery.TestFilename, ns, configMapName, testScriptPath, artillery.LabelPrefix)
 
 		msg, err := artillery.Generatables{

--- a/commands/generate.go
+++ b/commands/generate.go
@@ -46,12 +46,12 @@ func newCmdGenerate(
 		RunE:    makeRunGenTest(workingDir, io),
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			testScriptPath, _ := cmd.Flags().GetString("script")
-			env, _ := cmd.Flags().GetString("env")
+			ns, _ := cmd.Flags().GetString("namespace")
 			outPath, _ := cmd.Flags().GetString("out")
 			count, _ := cmd.Flags().GetInt("count")
 
 			logger := artillery.NewIOLogger(io.Out, io.ErrOut)
-			telemetry.TelemeterGenerateManifests(args[0], testScriptPath, env, outPath, count, tClient, tCfg, logger)
+			telemetry.TelemeterGenerateManifests(args[0], testScriptPath, ns, outPath, count, tClient, tCfg, logger)
 			return nil
 		},
 	}

--- a/internal/artillery/job.go
+++ b/internal/artillery/job.go
@@ -15,6 +15,7 @@ package artillery
 import (
 	"encoding/json"
 
+	"github.com/artilleryio/kubectl-artillery/internal/telemetry"
 	"k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,7 +26,7 @@ type Job struct {
 }
 
 // NewTestJob returns a configured Kubernetes Job wrapper for an Artillery  test.
-func NewTestJob(testName, namespace, configMapName, testScriptFilename string, count int) *Job {
+func NewTestJob(testName, namespace, configMapName, testScriptFilename string, count int, cfg telemetry.Config) *Job {
 	var (
 		parallelism  int32 = 1
 		completions  int32 = 1
@@ -87,6 +88,9 @@ func NewTestJob(testName, namespace, configMapName, testScriptFilename string, c
 											},
 										},
 									},
+									// These are telemetry settings passed to to the Artillery image
+									// as per an end user's environment.
+									cfg.ToK8sEnvVar()...,
 								),
 							},
 						},

--- a/internal/telemetry/telemeter.go
+++ b/internal/telemetry/telemeter.go
@@ -50,7 +50,7 @@ func TelemeterServicesScaffold(
 
 // TelemeterGenerateManifests enqueues a kubectl-artillery generate command event.
 func TelemeterGenerateManifests(
-	name, testScriptPath, env, outPath string,
+	name, testScriptPath, namespace, outPath string,
 	count int,
 	tClient posthog.Client,
 	tConfig Config,
@@ -66,7 +66,7 @@ func TelemeterGenerateManifests(
 				"name":             hashEncode(name),
 				"testScript":       hashEncode(testScriptPath),
 				"count":            count,
-				"environment":      hashEncode(env),
+				"namespace":        hashEncode(namespace),
 				"defaultOutputDir": len(outPath) == 0,
 			},
 		},


### PR DESCRIPTION
Resolves https://linear.app/artillery/issue/ART-461

## Updates:

- the environment flag is no longer used and doesn't need to be tracked by telemetry events.
- the namespace flag has been introduced and should be tracked by telemetry events.
- pass telemetry environment settings to the generated Job's artillery workers.